### PR TITLE
Add fix for GL.End requires material.SetPass

### DIFF
--- a/Creation Sandbox/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
+++ b/Creation Sandbox/Assets/SteamVR/Scripts/SteamVR_UpdatePoses.cs
@@ -14,7 +14,7 @@ public class SteamVR_UpdatePoses : MonoBehaviour
 	{
 		var camera = GetComponent<Camera>();
 		camera.stereoTargetEye = StereoTargetEyeMask.None;
-		camera.clearFlags = CameraClearFlags.Nothing;
+		//camera.clearFlags = CameraClearFlags.Nothing;
 		camera.useOcclusionCulling = false;
 		camera.cullingMask = 0;
 		camera.depth = -9999;


### PR DESCRIPTION
Unity issue: 872062
https://issuetracker.unity3d.com/issues/gl-dot-end-error-is-thrown-if-a-cameras-clear-flags-is-set-to-depth-only